### PR TITLE
[WHD-43] cookie the MCE form submission to prevent repeats

### DIFF
--- a/html/themes/whd2021/templates/components/mailchimp-signup/paragraph--mailchimp-signup.js
+++ b/html/themes/whd2021/templates/components/mailchimp-signup/paragraph--mailchimp-signup.js
@@ -5,11 +5,30 @@
       $mcForm = $('#mc-embedded-subscribe-form');
       $mcComponent = $('.mailchimp-signup');
       $shareComponent = $('.share');
+      cookieValue = 'whd2021signup=true';
 
+      // MailChimp Embed submission handler.
       $mcForm.on('submit', function handleMCSubmit(ev) {
-        $mcComponent.addClass('mailchimp-signup--is-hidden');
-        $shareComponent.addClass('share--is-visible');
+        transitionUi();
+
+        // Set submission cookie
+        // So that the MCE form won't show next time the page loads.
+        document.cookie = cookieValue +'; path=/; max-age=31536000; SameSite=Strict';
       });
+
+      // Check submission cookie
+      // If the cookie exists, update the UI to show Share dialog automatically.
+      if (document.cookie.indexOf(cookieValue) !== -1) {
+        transitionUi();
+      }
+
+      /**
+       * Helper function to transition the UI uniformly across multiple events
+       */
+      function transitionUi() {
+        $mcComponent.addClass('mailchimp-signup--is-hidden').attr('aria-hidden', 'true');
+        $shareComponent.addClass('share--is-visible').attr('aria-hidden', 'false');
+      }
     },
   };
 })(jQuery);


### PR DESCRIPTION
# WHD-43

the cookie is in place and repeat visitors will only see Share dialog. Cookie expires in one year, but I also named it `whd2021signup` so there's no chance for name collisions later on.