### PR TITLE
[WHD-48] allow MailChimp form strings to be translated

### DIFF
--- a/html/themes/whd2021/templates/components/mailchimp-signup/paragraph--mailchimp-signup.html.twig
+++ b/html/themes/whd2021/templates/components/mailchimp-signup/paragraph--mailchimp-signup.html.twig
@@ -62,20 +62,20 @@
           <div id="mc_embed_signup_scroll" class="[ flow ]">
             <div class="mc-field-group">
               <label for="mce-FNAME" class="visually-hidden">First Name</label>
-              <input type="text" value="" name="FNAME" class="" id="mce-FNAME" placeholder="First name">
+              <input type="text" value="" name="FNAME" class="" id="mce-FNAME" placeholder="{{ 'First name'|t }}">
             </div>
             <div class="mc-field-group">
               <label for="mce-LNAME" class="visually-hidden">Last Name</label>
-              <input type="text" value="" name="LNAME" class="" id="mce-LNAME" placeholder="Last name">
+              <input type="text" value="" name="LNAME" class="" id="mce-LNAME" placeholder="{{ 'Last name'|t }}">
             </div>
             <div class="mc-field-group">
               <label for="mce-EMAIL" class="visually-hidden">Email Address</label>
-              <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="you@example.com" required>
+              <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="{{ 'you@example.com'|t }}" required>
             </div>
             <div class="mc-field-group">
               <label for="mce-COUNTRY" class="visually-hidden">Country</label>
               <select name="COUNTRY" class="" id="mce-COUNTRY" required>
-                <option value="">- Select a Country -</option>
+                <option value="">- {{ 'Select a Country'|t }} -</option>
                 <option value="Afghanistan">{{ 'Afghanistan'|t }}</option>
                 <option value="Aland Islands">{{ 'Aland Islands'|t }}</option>
                 <option value="Albania">{{ 'Albania'|t }}</option>


### PR DESCRIPTION
# WHD-48

While reviewing Russian translations I came across a few untranslatable strings in the MailChimp form.