### PR TITLE
[WHD-48] allow Editor role to edit Menus

### DIFF
--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -10,6 +10,7 @@ permissions:
   - 'access administration pages'
   - 'access content overview'
   - 'access media overview'
+  - 'administer menu'
   - 'administer nodes'
   - 'bypass node access'
   - 'create content translations'


### PR DESCRIPTION
# WHD-48

Editor needs additional permissions to edit/translate site Menus.