### PR TITLE
[WHD-50] modify MailChimp to match our current translation GSS

### DIFF
--- a/html/themes/whd2021/templates/components/mailchimp-signup/paragraph--mailchimp-signup.html.twig
+++ b/html/themes/whd2021/templates/components/mailchimp-signup/paragraph--mailchimp-signup.html.twig
@@ -61,21 +61,17 @@
         <form action="https://unocha.us2.list-manage.com/subscribe/post?u=83487eb1105d72ff2427e4bd7&amp;id=e5b827be98" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
           <div id="mc_embed_signup_scroll" class="[ flow ]">
             <div class="mc-field-group">
-              <label for="mce-FNAME" class="visually-hidden">First Name</label>
-              <input type="text" value="" name="FNAME" class="" id="mce-FNAME" placeholder="{{ 'First name'|t }}">
+              <label for="mce-NAME" class="visually-hidden">{{ 'Name'|t }}</label>
+              <input type="text" value="" name="NAME" class="" id="mce-NAME" placeholder="{{ 'Name'|t }}">
             </div>
             <div class="mc-field-group">
-              <label for="mce-LNAME" class="visually-hidden">Last Name</label>
-              <input type="text" value="" name="LNAME" class="" id="mce-LNAME" placeholder="{{ 'Last name'|t }}">
-            </div>
-            <div class="mc-field-group">
-              <label for="mce-EMAIL" class="visually-hidden">Email Address</label>
+              <label for="mce-EMAIL" class="visually-hidden">{{ 'Email Address'|t }}</label>
               <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="{{ 'you@example.com'|t }}" required>
             </div>
             <div class="mc-field-group">
               <label for="mce-COUNTRY" class="visually-hidden">Country</label>
               <select name="COUNTRY" class="" id="mce-COUNTRY" required>
-                <option value="">- {{ 'Select a Country'|t }} -</option>
+                <option value="">- {{ 'Country'|t }} -</option>
                 <option value="Afghanistan">{{ 'Afghanistan'|t }}</option>
                 <option value="Aland Islands">{{ 'Aland Islands'|t }}</option>
                 <option value="Albania">{{ 'Albania'|t }}</option>


### PR DESCRIPTION
# WHD-50

MailChimp data model already updated at time of commit, so this updates the template to reduce fields and use the exact strings that were already in our canonical GSS.