### PR TITLE
[WHD-67] ensure languages don't overflow on small screens

### DIFF
--- a/html/themes/whd2021/templates/components/front-page/front-page.css
+++ b/html/themes/whd2021/templates/components/front-page/front-page.css
@@ -10,7 +10,7 @@
   align-items: flex-start;
   width: 100%;
   height: 18vw;
-  padding: 0 2rem;
+  padding: 0 .5rem;
 }
 
 @media screen and (min-width: 34em) {
@@ -19,6 +19,7 @@
     top: 6rem;
     z-index: 10;
     height: 15vw;
+    padding: 0 2rem;
   }
 }
 

--- a/html/themes/whd2021/templates/components/global-header/global-header.css
+++ b/html/themes/whd2021/templates/components/global-header/global-header.css
@@ -10,9 +10,15 @@
   z-index: 20;
 
   /* visual */
-  padding: 1rem;
+  padding: 1rem .5rem;
   background: white;
   color: black;
+}
+
+@media screen and (min-width: 30em) {
+  .global-header {
+    padding: 1rem;
+  }
 }
 
 .global-header #block-whd2021-account-menu li {
@@ -49,8 +55,10 @@
   font-size: .75em;
 }
 
-.language-switcher-language-url .links li:last-child a {
-  padding-inline-end: 2rem;
+@media screen and (min-width: 30em) {
+  .language-switcher-language-url .links li:last-child a {
+    padding-inline-end: 2rem;
+  }
 }
 
 .language-switcher-language-url .links a.is-active {


### PR DESCRIPTION
# WHD-67

Language switcher needed some love on mobile. You can squeeze down to about 366px before things start overflowing. If we need to go lower than that, perhaps we can use language codes at really small sizes.