### PR TITLE
[WHD-76] Implement a SiteAuditCheck for the Editor role

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "drupal/paragraphs": "^1.12",
         "drupal/pathauto": "^1.8",
         "drupal/redis": "^1.5",
+        "drupal/site_audit": "^3",
         "drupal/social_api": "^3.0",
         "drupal/social_auth": "^3.0.1",
         "drupal/social_auth_hid": "2.x-dev@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1da1cf6b87cf7601ff325d15da542795",
+    "content-hash": "e8b687dd1848233ec9168eece043e4c5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3343,6 +3343,65 @@
             "homepage": "https://www.drupal.org/project/redis",
             "support": {
                 "source": "https://git.drupalcode.org/project/redis"
+            }
+        },
+        {
+            "name": "drupal/site_audit",
+            "version": "3.0.0-rc2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/site_audit.git",
+                "reference": "8.x-3.0-rc2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/site_audit-8.x-3.0-rc2.zip",
+                "reference": "8.x-3.0-rc2",
+                "shasum": "91310cccd69d2fed2a7bdb1d0a9034c0514f5afd"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "php": ">=5.6.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.0-rc2",
+                    "datestamp": "1609950103",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9 || ^10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "James Glasgow",
+                    "homepage": "https://www.drupal.org/user/1386596",
+                    "email": "james@jrglasgow.com"
+                },
+                {
+                    "name": "jrglasgow",
+                    "homepage": "https://www.drupal.org/user/36590"
+                },
+                {
+                    "name": "leymannx",
+                    "homepage": "https://www.drupal.org/user/2482808"
+                }
+            ],
+            "description": "This extension provides Site Audit commands for The Drupal UI and Drush.",
+            "homepage": "https://www.drupal.org/project/site_audit",
+            "support": {
+                "source": "https://git.drupalcode.org/project/site_audit"
             }
         },
         {

--- a/html/modules/custom/ocha_audit/ocha_audit.info.yml
+++ b/html/modules/custom/ocha_audit/ocha_audit.info.yml
@@ -1,0 +1,9 @@
+type: module
+name: OCHA Site Audit
+description: OCHA-specific extensions to the Site Audit module.
+package: Development
+core_version_requirement: ^8.8 || ^9
+php: 7.4
+tags:
+ - developer
+ - ocha

--- a/html/modules/custom/ocha_audit/src/Plugin/SiteAuditCheck/OchaRolesEditor.php
+++ b/html/modules/custom/ocha_audit/src/Plugin/SiteAuditCheck/OchaRolesEditor.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\ocha_audit\Plugin\SiteAuditCheck;
+
+use Drupal\site_audit\Plugin\SiteAuditCheckBase;
+
+/**
+ * Provides the OchaRolesEditor Check.
+ *
+ * @SiteAuditCheck(
+ *  id = "ocha_roles_editor",
+ *  name = @Translation("OCHA Editor role"),
+ *  description = @Translation("Confirm that an Editor role exists."),
+ *  report = "users"
+ * )
+ */
+class OchaRolesEditor extends SiteAuditCheckBase {
+
+  /**
+   * {@inheritdoc}.
+   */
+  public function getResultFail() {
+    return $this->t('Editor role was not found!');
+  }
+
+  /**
+   * {@inheritdoc}.
+   */
+  public function getResultInfo() {}
+
+  /**
+   * {@inheritdoc}.
+   */
+  public function getResultPass() {
+    return $this->t('Editor role was found.');
+  }
+
+  /**
+   * {@inheritdoc}.
+   */
+  public function getResultWarn() {}
+
+  /**
+   * {@inheritdoc}.
+   */
+  public function getAction() {
+    if ($this->score != SiteAuditCheckBase::AUDIT_CHECK_SCORE_PASS) {
+      return $this->t('Create Editor role with machine name "editor"');
+    }
+  }
+
+  /**
+   * {@inheritdoc}.
+   */
+  public function calculateScore() {
+    $query = \Drupal::database()->select('user__roles');
+    $query->addExpression('COUNT(entity_id)', 'count');
+    $query->addfield('user__roles', 'roles_target_id', 'name');
+    $query->groupBy('name');
+    $query->orderBy('name', 'ASC');
+    $results = $query->execute();
+    while ($row = $results->fetchObject()) {
+      $this->registry->roles[$row->name] = $row->count;
+    }
+
+    if ($this->registry->roles['editor'] > 0) {
+      return SiteAuditCheckBase::AUDIT_CHECK_SCORE_PASS;
+    }
+    return SiteAuditCheckBase::AUDIT_CHECK_SCORE_FAIL;
+  }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -140,6 +140,9 @@
     "drupal/redis": {
         "version": "1.5.0"
     },
+    "drupal/site_audit": {
+        "version": "2.2.0"
+    },
     "drupal/social_api": {
         "version": "2.0.0-rc4"
     },


### PR DESCRIPTION
# WHD-76

No config yet, because I don't actually want to enable this until it's working 100%.

```sh
composer install
drush en site_audit ocha_audit
drush site_audit:audit
> 12 # Choose "Users" report
```

If there's a failure (e.g. if I falsify the test itself to check for a role called `bananas`) then it outputs the Error along with the `Action` text. However if it passes, the only output is a single line-break (look after `Identity UID #1`). I know it's still working, because with the `ocha_audit` module disabled the Heading reports 3%, but enabling the module turns it to 50% despite the missing success message.

```
------------------------------------------------------------------------------------------------------
                                      Report: Users - 50%
------------------------------------------------------------------------------------------------------
[Users - Count All] Total number of Drupal users.
[Users - Count All] Result: Note
[Users - Count All] There are 6 users.

[Users - Identify UID #1] Show username and email of UID #1.
[Users - Identify UID #1] Result: Note
[Users - Identify UID #1] UID #1: A29398fZre494w3q, email: admin@example.com


[Users - UID #1 access] Determine if UID #1 is blocked.
[Users - UID #1 access] Result: Error
[Users - UID #1 access] UID #1 is not blocked!
[Users - UID #1 access] Action: Block UID #1

[Users - Count Blocked] Total number of blocked Drupal users.
[Users - Count Blocked] Result: Note
[Users - Count Blocked] There are 2 blocked users.

[Users - List Roles] Show all available roles and user counts.
[Users - List Roles] Result: Note
[Users - List Roles] administrator: 2<br/>editor: 3
```