### PR TITLE
[WHD-78] ensure Hamburger smooth-scroll works on all languages

### DIFF
--- a/html/themes/whd2021/templates/components/front-page/front-page.js
+++ b/html/themes/whd2021/templates/components/front-page/front-page.js
@@ -10,7 +10,7 @@
       if (window.matchMedia('(prefers-reduced-motion: reduce)').matches === false) {
         $mainNavLinks.on('click', function smoothScroll (ev) {
           ev.preventDefault();
-          var target = $(this).attr('href').replace('/','');
+          var target = '#' + $(this).attr('href').split('#')[1];
           $(target).get(0).scrollIntoView({behavior: 'smooth'});
         });
       }


### PR DESCRIPTION
# WHD-78

I obviously didn't test the smooth scrolling on anything but English. It was choking on paths with language codes but now it looks exclusively at the anchor and jumps there.